### PR TITLE
Force display of plot for users launching the output scripts from the terminal

### DIFF
--- a/src/IO/Python.py
+++ b/src/IO/Python.py
@@ -513,6 +513,7 @@ class RGEsolver():
 
             plt.legend(cNames)
             plt.xlabel(r't',fontsize=17-len(allCouplingsByType))
+        plt.show()
 
 
     #########################


### PR DESCRIPTION
**Minor change in the PythonOutput.** (`src/IO/Python.py`)

Simply add a `plt.show()` in the `[modelName].py` to force the display of the results from `rge.plot(args)`.

_This change is necessary for users launching scripts of the `PythonOutput/` directory from a terminal, however, it won't have any effects for users using IPython shell or Notebook._